### PR TITLE
Ordered dictionary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "OrderedCollections",
-            targets: ["RedBlackTree"]),
+            targets: ["OrderedCollections"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -22,10 +22,16 @@ let package = Package(
             name: "RedBlackTree",
             dependencies: []),
         .target(
+            name: "OrderedCollections",
+            dependencies: ["RedBlackTree"]),
+        .target(
             name: "TestValues",
             dependencies: []),
         .testTarget(
             name: "RedBlackTreeTests",
             dependencies: ["RedBlackTree", "TestValues"]),
+        .testTarget(
+            name: "OrderedCollectionsTests",
+            dependencies: ["OrderedCollections", "TestValues"])
     ]
 )

--- a/Sources/OrderedCollections/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary.swift
@@ -1,0 +1,63 @@
+//
+//  OrderedDictionary.swift
+//  OrderedCollections
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2020 Greg Omelaenko
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import RedBlackTree
+
+// TODO: this shouldn't just be a typealias, it should be a full wrapper, because RedBlackTree supports duplicate keys. the current RedBlackTreeIndex comparison function is probably wrong and should be removed.
+public typealias OrderedDictionary<Key: Comparable, Value> = RedBlackTree<Key, Value>
+
+extension OrderedDictionary {
+    
+    public subscript(key: Key) -> Value? {
+        get {
+            guard let index = find(key) else { return nil }
+            return self[index].value
+        }
+        set {
+            if let index = find(key) {
+                if let newValue = newValue {
+                    updateValue(newValue, atIndex: index)
+                }
+                else {
+                    remove(at: index)
+                }
+            }
+            else if let newValue = newValue {
+                insert(key, with: newValue)
+            }
+        }
+    }
+    
+    public subscript(key: Key, default defaultValue: @autoclosure () -> Value) -> Value {
+        get {
+            return self[key] ?? defaultValue()
+        }
+        set {
+            self[key] = newValue
+        }
+    }
+}

--- a/Sources/OrderedCollections/OrderedDictionary.swift
+++ b/Sources/OrderedCollections/OrderedDictionary.swift
@@ -25,33 +25,37 @@
 //  SOFTWARE.
 //
 
+import Swift
 import RedBlackTree
 
-// TODO: this shouldn't just be a typealias, it should be a full wrapper, because RedBlackTree supports duplicate keys. the current RedBlackTreeIndex comparison function is probably wrong and should be removed.
-public typealias OrderedDictionary<Key: Comparable, Value> = RedBlackTree<Key, Value>
-
-extension OrderedDictionary {
+public struct OrderedDictionary<Key: Comparable, Value> {
+    
+    private var tree: RedBlackTree<Key, Value>
+    
+    init<S>(uniqueKeysWithValues keysAndValues: S) where S : Sequence, S.Element == (Key, Value) {
+        self.tree = RedBlackTree(keysAndValues)
+    }
     
     public subscript(key: Key) -> Value? {
         get {
-            guard let index = find(key) else { return nil }
-            return self[index].value
+            guard let index = tree.find(key) else { return nil }
+            return tree[index].value
         }
         set {
-            if let index = find(key) {
+            if let index = tree.find(key) {
                 if let newValue = newValue {
-                    updateValue(newValue, atIndex: index)
+                    tree.updateValue(newValue, atIndex: index)
                 }
                 else {
-                    remove(at: index)
+                    tree.remove(at: index)
                 }
             }
             else if let newValue = newValue {
-                insert(key, with: newValue)
+                tree.insert(key, with: newValue)
             }
         }
     }
-    
+
     public subscript(key: Key, default defaultValue: @autoclosure () -> Value) -> Value {
         get {
             return self[key] ?? defaultValue()
@@ -59,5 +63,38 @@ extension OrderedDictionary {
         set {
             self[key] = newValue
         }
+    }
+    
+    public var count: Int {
+        return 0
+    }
+}
+
+extension OrderedDictionary: Collection {
+    
+    public typealias Index = RedBlackTreeIndex<Key, Value>
+    public typealias Element = (key: Key, value: Value)
+    
+    public var startIndex: Index {
+        return tree.startIndex
+    }
+    
+    public var endIndex: Index {
+        return tree.endIndex
+    }
+    
+    public func index(after i: RedBlackTreeIndex<Key, Value>) -> Index {
+        return tree.index(after: i)
+    }
+    
+    public subscript(position: Index) -> Element {
+        return tree[position]
+    }
+}
+
+extension OrderedDictionary: ExpressibleByDictionaryLiteral {
+    
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self.init(uniqueKeysWithValues: elements)
     }
 }

--- a/Sources/RedBlackTree/RedBlackTree.swift
+++ b/Sources/RedBlackTree/RedBlackTree.swift
@@ -300,6 +300,7 @@ public struct RedBlackTree<Key : Comparable, Value> {
     /// If this is the *first* modification to the tree since creation or copying, invalidates all indices with respect to `self`.
     ///
     /// - Complexity: O(1).
+    @discardableResult
     public mutating func updateValue(_ value: Value, atIndex index: Index) -> Value {
         precondition(index._safe, "Cannot update an index that is out of range.")
         let v = index.node!.value!
@@ -442,7 +443,7 @@ extension RedBlackTree: Sequence {
 
 extension RedBlackTree: Collection {
 
-    public typealias Element = (Key, Value)
+    public typealias Element = (key: Key, value: Value)
     public typealias Index = RedBlackTreeIndex<Key, Value>
 
     /// - Complexity: O(1)
@@ -494,9 +495,16 @@ extension RedBlackTree {
 
 }
 
-extension RedBlackTree : ExpressibleByArrayLiteral {
+extension RedBlackTree: ExpressibleByArrayLiteral {
 
     public init(arrayLiteral elements: Element...) {
+        self.init(elements)
+    }
+}
+
+extension RedBlackTree: ExpressibleByDictionaryLiteral {
+    
+    public init(dictionaryLiteral elements: (Key, Value)...) {
         self.init(elements)
     }
 }

--- a/Sources/RedBlackTree/RedBlackTree.swift
+++ b/Sources/RedBlackTree/RedBlackTree.swift
@@ -464,8 +464,12 @@ extension RedBlackTree: Collection {
     ///
     /// - Complexity: O(1)
     public subscript(index: Index) -> Element {
-        guard case .node(let u) = index.kind else { preconditionFailure("Cannot subscript an out-of-bounds index.") }
-        return (u.value.key, u.value.value)
+        switch index.kind {
+        case .node(let u):
+            return (u.value.key, u.value.value)
+        case .end, .empty:
+            preconditionFailure("Cannot subscript an out-of-bounds index.")
+        }
     }
 
     /// - Complexity: Amortised O(1) across a full iteration of the collection.
@@ -475,7 +479,7 @@ extension RedBlackTree: Collection {
 }
 
 extension RedBlackTree: RandomAccessCollection {
-    
+
     public func index(before i: Index) -> Index {
         return i.predecessor()
     }
@@ -498,13 +502,6 @@ extension RedBlackTree {
 extension RedBlackTree: ExpressibleByArrayLiteral {
 
     public init(arrayLiteral elements: Element...) {
-        self.init(elements)
-    }
-}
-
-extension RedBlackTree: ExpressibleByDictionaryLiteral {
-    
-    public init(dictionaryLiteral elements: (Key, Value)...) {
         self.init(elements)
     }
 }

--- a/Sources/RedBlackTree/RedBlackTreeIndex.swift
+++ b/Sources/RedBlackTree/RedBlackTreeIndex.swift
@@ -100,7 +100,7 @@ public struct RedBlackTreeIndex<Key: Comparable, Value> {
 extension RedBlackTreeIndex: IteratorProtocol {
     
     /// - Complexity: Amortised O(1) over a full iteration of the collection.
-    public mutating func next() -> (Key, Value)? {
+    public mutating func next() -> (key: Key, value: Value)? {
         switch kind {
         case .node(let u):
             defer {

--- a/Sources/RedBlackTree/RedBlackTreeIndex.swift
+++ b/Sources/RedBlackTree/RedBlackTreeIndex.swift
@@ -127,7 +127,7 @@ extension RedBlackTreeIndex: Equatable {
 }
 
 extension RedBlackTreeIndex: Comparable {
-    
+
     /// - Complexity: O(1)
     public static func < (lhs: RedBlackTreeIndex, rhs: RedBlackTreeIndex) -> Bool {
         switch (lhs.kind, rhs.kind) {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,8 @@
 import XCTest
 
-import OrderedCollectionsTests
+import RedBlackTreeTests
 
 var tests = [XCTestCaseEntry]()
+tests += RedBlackTreeTests.allTests()
 tests += OrderedCollectionsTests.allTests()
 XCTMain(tests)

--- a/Tests/OrderedCollectionsTests/OrderedCollectionsTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedCollectionsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import OrderedCollections
+import TestValues
+
+final class OrderedCollectionsTestsTests: XCTestCase {
+    
+    func testOrderedDictionary() {
+        var a: OrderedDictionary = [5: "hello", 6: "aoeu", -1: ""]
+//        XCTAssertEqual(a[5], "hello")
+//        XCTAssertEqual(a[6], "aoeu")
+//        XCTAssertEqual(a[-1], "")
+//        a[2] = "htns"
+//        XCTAssertEqual(a[2], "htns")
+//        a[5] = "bye"
+//        XCTAssertEqual(a[5], "bye")
+//        a.removeValueForKey(6)
+//        XCTAssertEqual(a.count, 3)
+    }
+}

--- a/Tests/OrderedCollectionsTests/OrderedCollectionsTests.swift
+++ b/Tests/OrderedCollectionsTests/OrderedCollectionsTests.swift
@@ -2,18 +2,18 @@ import XCTest
 @testable import OrderedCollections
 import TestValues
 
-final class OrderedCollectionsTestsTests: XCTestCase {
+final class OrderedCollectionsTests: XCTestCase {
     
     func testOrderedDictionary() {
         var a: OrderedDictionary = [5: "hello", 6: "aoeu", -1: ""]
-//        XCTAssertEqual(a[5], "hello")
-//        XCTAssertEqual(a[6], "aoeu")
-//        XCTAssertEqual(a[-1], "")
-//        a[2] = "htns"
-//        XCTAssertEqual(a[2], "htns")
-//        a[5] = "bye"
-//        XCTAssertEqual(a[5], "bye")
-//        a.removeValueForKey(6)
-//        XCTAssertEqual(a.count, 3)
+        XCTAssertEqual(a[5], "hello")
+        XCTAssertEqual(a[6], "aoeu")
+        XCTAssertEqual(a[-1], "")
+        a[2] = "htns"
+        XCTAssertEqual(a[2], "htns")
+        a[5] = "bye"
+        XCTAssertEqual(a[5], "bye")
+        a[6] = nil
+        XCTAssertEqual(a.count, 3)
     }
 }

--- a/Tests/OrderedCollectionsTests/XCTestManifests.swift
+++ b/Tests/OrderedCollectionsTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(RedBlackTreeTests.allTests),
+        testCase(OrderedCollectionsTests.allTests),
     ]
 }
 #endif

--- a/Tests/RedBlackTreeTests/RedBlackTreeTests.swift
+++ b/Tests/RedBlackTreeTests/RedBlackTreeTests.swift
@@ -47,6 +47,11 @@ final class RedBlackTreeTests: XCTestCase {
             XCTAssert(t.map({ $0.0 }).elementsEqual(nums))
         }
     }
+    
+    func testDuplicateInsert() {
+        let t: RedBlackTree = [3: 1, 3: 3, 3: 2, 3: 5, 3: 7, 3: -1]
+        XCTAssertEqual(Array(t).map(\.value), [1, 3, 2, 5, 7, -1])
+    }
 
     func testIndexing() {
         var a = RedBlackTree<Int, ()>([1, 2, 3, 4, 5].map { ($0, ()) })

--- a/Tests/RedBlackTreeTests/RedBlackTreeTests.swift
+++ b/Tests/RedBlackTreeTests/RedBlackTreeTests.swift
@@ -49,7 +49,7 @@ final class RedBlackTreeTests: XCTestCase {
     }
     
     func testDuplicateInsert() {
-        let t: RedBlackTree = [3: 1, 3: 3, 3: 2, 3: 5, 3: 7, 3: -1]
+        let t: RedBlackTree = [(3, 1), (3, 3), (3, 2), (3, 5), (3, 7), (3, -1)]
         XCTAssertEqual(Array(t).map(\.value), [1, 3, 2, 5, 7, -1])
     }
 


### PR DESCRIPTION
- [ ] remove `Comparable` from `RedBlackTreeIndex` because that comparison function is wrong (`RedBlackTree` can have multiple elements with the same index and it doesn't take that into account)

- [ ] implement all the fancy collection functions on `OrderedDictionary` instead